### PR TITLE
Allow players to toggle inventory with I

### DIFF
--- a/rpg/views/inventory_view.py
+++ b/rpg/views/inventory_view.py
@@ -32,5 +32,9 @@ class InventoryView(arcade.View):
         arcade.set_viewport(0, self.window.width, 0, self.window.height)
 
     def on_key_press(self, symbol: int, modifiers: int):
-        if symbol == arcade.key.ESCAPE:
+        close_inputs = [
+            arcade.key.ESCAPE,
+            arcade.key.I
+        ]
+        if symbol in close_inputs:
             self.window.show_view(self.window.views["game"])


### PR DESCRIPTION
Prior to this change, players were not able to toggle the inventory window with the [I] key. Instead, they were only able to close out of the inventory view by pressing [Esc].

This change allows players to both open and close the inventory window with [I] and retain the ability to close with [Esc].