### PR TITLE
Fix diagonal move speed

### DIFF
--- a/rpg/views/game_view.py
+++ b/rpg/views/game_view.py
@@ -213,14 +213,83 @@ class GameView(arcade.View):
         self.player_sprite.change_x = 0
         self.player_sprite.change_y = 0
 
-        if self.up_pressed and not self.down_pressed:
+        MOVING_UP = (
+            self.up_pressed
+            and not self.down_pressed
+            and not self.right_pressed
+            and not self.left_pressed
+        )
+
+        MOVING_DOWN = (
+            self.down_pressed
+            and not self.up_pressed
+            and not self.right_pressed
+            and not self.left_pressed
+        )
+
+        MOVING_RIGHT = (
+            self.right_pressed
+            and not self.left_pressed
+            and not self.up_pressed
+            and not self.down_pressed
+        )
+
+        MOVING_LEFT = (
+            self.left_pressed
+            and not self.right_pressed
+            and not self.up_pressed
+            and not self.down_pressed
+        )
+
+        MOVING_UP_LEFT = (
+            self.up_pressed
+            and self.left_pressed
+            and not self.down_pressed
+            and not self.right_pressed
+        )
+
+        MOVING_DOWN_LEFT = (
+            self.down_pressed
+            and self.left_pressed
+            and not self.up_pressed
+            and not self.right_pressed
+        )
+
+        MOVING_UP_RIGHT = (
+            self.up_pressed
+            and self.right_pressed
+            and not self.down_pressed
+            and not self.left_pressed
+        )
+
+        MOVING_DOWN_RIGHT = (
+            self.down_pressed
+            and self.right_pressed
+            and not self.up_pressed
+            and not self.left_pressed
+        )
+
+        if MOVING_UP:
             self.player_sprite.change_y = constants.MOVEMENT_SPEED
-        elif self.down_pressed and not self.up_pressed:
+        elif MOVING_DOWN:
             self.player_sprite.change_y = -constants.MOVEMENT_SPEED
-        if self.left_pressed and not self.right_pressed:
+        if MOVING_LEFT:
             self.player_sprite.change_x = -constants.MOVEMENT_SPEED
-        elif self.right_pressed and not self.left_pressed:
+        elif MOVING_RIGHT:
             self.player_sprite.change_x = constants.MOVEMENT_SPEED
+        elif MOVING_UP_LEFT:
+            self.player_sprite.change_y = constants.MOVEMENT_SPEED / 1.5
+            self.player_sprite.change_x = - constants.MOVEMENT_SPEED / 1.5
+        elif MOVING_UP_RIGHT:
+            self.player_sprite.change_y = constants.MOVEMENT_SPEED / 1.5
+            self.player_sprite.change_x = constants.MOVEMENT_SPEED / 1.5
+        elif MOVING_DOWN_LEFT:
+            self.player_sprite.change_y = - constants.MOVEMENT_SPEED / 1.5
+            self.player_sprite.change_x = - constants.MOVEMENT_SPEED / 1.5
+        elif MOVING_DOWN_RIGHT:
+            self.player_sprite.change_y = - constants.MOVEMENT_SPEED / 1.5
+            self.player_sprite.change_x = constants.MOVEMENT_SPEED / 1.5
+
 
         # Call update to move the sprite
         self.physics_engine.update()


### PR DESCRIPTION
Prior to this change, the character velocity, when moving diagonally, was too fast. (When moving up/down and left/right)

This change fixes the movement speed for diagonal movements.