### PR TITLE
Fix vec2 typing

### DIFF
--- a/rpg/views/game_view.py
+++ b/rpg/views/game_view.py
@@ -9,6 +9,7 @@ import rpg.constants as constants
 from arcade.experimental.lights import Light
 from rpg.player_sprite import PlayerSprite
 from rpg.message_box import MessageBox
+from pyglet.math import Vec2
 
 
 class GameView(arcade.View):
@@ -192,11 +193,11 @@ class GameView(arcade.View):
     def scroll_to_player(self, speed=constants.CAMERA_SPEED):
         """Manage Scrolling"""
 
-        position = (
+        vector = Vec2(
             self.player_sprite.center_x - self.window.width / 2,
             self.player_sprite.center_y - self.window.height / 2,
         )
-        self.camera_sprites.move_to(position, speed)
+        self.camera_sprites.move_to(vector, speed)
 
     def on_show_view(self):
         # Set background color

--- a/rpg/views/game_view.py
+++ b/rpg/views/game_view.py
@@ -7,7 +7,6 @@ import json
 import arcade
 import rpg.constants as constants
 from arcade.experimental.lights import Light
-from rpg.character_sprite import CharacterSprite
 from rpg.player_sprite import PlayerSprite
 from rpg.message_box import MessageBox
 
@@ -284,20 +283,19 @@ class GameView(arcade.View):
 
         if MOVING_UP_LEFT:
             self.player_sprite.change_y = constants.MOVEMENT_SPEED / 1.5
-            self.player_sprite.change_x = - constants.MOVEMENT_SPEED / 1.5
+            self.player_sprite.change_x = -constants.MOVEMENT_SPEED / 1.5
 
         if MOVING_UP_RIGHT:
             self.player_sprite.change_y = constants.MOVEMENT_SPEED / 1.5
             self.player_sprite.change_x = constants.MOVEMENT_SPEED / 1.5
 
         if MOVING_DOWN_LEFT:
-            self.player_sprite.change_y = - constants.MOVEMENT_SPEED / 1.5
-            self.player_sprite.change_x = - constants.MOVEMENT_SPEED / 1.5
+            self.player_sprite.change_y = -constants.MOVEMENT_SPEED / 1.5
+            self.player_sprite.change_x = -constants.MOVEMENT_SPEED / 1.5
 
         if MOVING_DOWN_RIGHT:
-            self.player_sprite.change_y = - constants.MOVEMENT_SPEED / 1.5
+            self.player_sprite.change_y = -constants.MOVEMENT_SPEED / 1.5
             self.player_sprite.change_x = constants.MOVEMENT_SPEED / 1.5
-
 
         # Call update to move the sprite
         self.physics_engine.update()


### PR DESCRIPTION
Prior tot his change, there was an incorrect usage of `camera_sprites.move_to` because the provided arguments did not match the function signature.

This change updates the usage to correctly use a Vec2 type.