### PR TITLE
Update README discussion links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Graphics Assets From:
 
 ## Gameplay
 
-The game is in extremely early stages. For discussion on future direction, see: #31
+The game is in extremely early stages. For discussion on future direction, see:
+* [the github discussion board](https://github.com/pythonarcade/community-rpg/discussions).
+* [the #community-ideas channel on Arcade's discord server](https://discord.com/channels/458662222697070613/704736572603629589)
 
 ### Controls
 **Arrow Keys / WASD**: Movement


### PR DESCRIPTION
Closes #59 

tl;dr the readme doesn't properly embed a link to the discussion board, this links it directly and adds a link to the discord