### PR TITLE
Remove unneeded and broken turtle import

### DIFF
--- a/rpg/views/game_view.py
+++ b/rpg/views/game_view.py
@@ -4,7 +4,6 @@ Main game view
 
 import json
 from functools import partial
-from turtle import bgcolor, color
 from typing import Callable
 
 import arcade


### PR DESCRIPTION
Closes #63.

Game launches and appears to behave normally after the import is removed.