### PR TITLE
Fixed issue #53 rapid footsteps

### DIFF
--- a/rpg/sprites/player_sprite.py
+++ b/rpg/sprites/player_sprite.py
@@ -12,6 +12,10 @@ class PlayerSprite(CharacterSprite):
     def on_update(self, delta_time):
         super().on_update(delta_time)
 
+        if not self.change_x and not self.change_y:
+            self.sound_update = 0
+            return
+
         if self.should_update > 3:
             self.sound_update += 1
 


### PR DESCRIPTION
Sometimes the update in player_sprite.py would get stuck causing the footstep sound to play repeatedly. I believe this was due to the update loop self.should_update getting stuck at a value that was constantly updating the self.sound_update, causing the loop to trigger multiple times rapidly. By adding a reset to self.sound_update at the start it does not allow the sound to play unless the player is actually moving.