### PR TITLE
Fix deprecated config file variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
-line-length = 88
-py36 = true
+line-length = 89
+target_version = ['py38', 'py39', 'py10']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >= 3.7
+python_requires = >= 3.8
 setup_requires =
     setuptools >= 40.6
     pip >= 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,10 @@ version = "0.1.0"
 description = An Open Source RPG Game developed with Python using the Arcade library.
 long_description = file: README.md
 author = Paul Vincent Craven
-author-email = "paul.craven@simpson.edu"
+author_email = "paul.craven@simpson.edu"
 url = https://github.com/pythonarcade/community-rpg
 license = MIT
-license-file = LICENSE
+license_files = LICENSE
 
 classifiers =
     Development Status :: 1 - Planning


### PR DESCRIPTION
Fixes the following stylistic issues, some of which raise deprecation warnings when following install instructions:

1. dash style attributes for `author_email` and `license-file` are deprecated
2. black's py36 is option is deprecated / removed in favor of specifying versions in pyproject.toml.
3. [pre-commit shouldn't specify the python version for black](https://stackoverflow.com/a/69465958)