### PR TITLE
Fix version error from quotes in setup.cfg on some setuptools versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = community-rpg
-version = "0.1.0"
+version = 0.1.0
 description = An Open Source RPG Game developed with Python using the Arcade library.
 long_description = file: README.md
 author = Paul Vincent Craven


### PR DESCRIPTION
The removed quotes appear to cause problems when installing on some setuptools versions.